### PR TITLE
Bump max version to 8.2.1

### DIFF
--- a/printful.php
+++ b/printful.php
@@ -82,7 +82,7 @@ class Printful extends Module
 
         $this->ps_versions_compliancy = [
             'min' => '1.7.6',
-            'max' => '8.1.3',
+            'max' => '8.2.1',
         ];
         $this->bootstrap = true;
 


### PR DESCRIPTION
This pull request updates compatibility for PrestaShop versions in the `printful.php` file. The maximum supported version has been increased from `8.1.3` to `8.2.1`.